### PR TITLE
fix: fallback when no scheme is detected

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -1234,7 +1234,10 @@ local function select_device_which_key(devices)
 		end
 		table.insert(
 			cands,
-			{ on = tostring(allow_key_array[idx]), desc = (d.name or "NO_NAME") .. " (" .. d.scheme .. ")" }
+			{
+				on = tostring(allow_key_array[idx]),
+				desc = (d.name or "NO_NAME") .. " (" .. (d.scheme or "NO_SCHEME_DETECTED") .. ")",
+			}
 		)
 	end
 


### PR DESCRIPTION
Hi, 
I noticed, how when I try to mount my mounts, the display errors.
After some checking I noticed, its because I mount some of my stuff using fstab and thus gvfs doesn't know the scheme for it. 
(I use x-gvfs-show as option, so I can see those mounts in file explorers.)

This seems to fix it, but if there is a different point that may need this treatment, then let me know.