### PR TITLE
docs: added prepend_ to preloaders and previewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Replace `USER_NAME` with your real user name (run `whoami` to get username).
 
 ```toml
 [plugin]
-preloaders = [
+prepend_preloaders = [
   # Do not preload files in mounted locations:
   # Environment variable won't work here.
   # Using absolute path instead.
@@ -192,7 +192,7 @@ preloaders = [
   { name = "/run/media/USER_NAME/**/*", run = "noop" },
   #... the rest of preloaders
 ]
-previewers = [
+prepend_previewers = [
   # Allow to preview folder.
   { name = "*/", run = "folder", sync = true },
   # Do not previewing files in mounted locations (uncomment to except text file):


### PR DESCRIPTION
Hi,

Thank you for the plugin, it made mounting my phone much easier.

While customizing the `preloaders` and `previewers`, I noticed that defining them fully overrides the defaults. I initially tried to find what those were so as to re-add them manually. Parsing the docs, I discovered configuration mixing is supported (like with `keymap`) and avoids this issue from altogether.

- https://yazi-rs.github.io/docs/configuration/yazi/#plugin.preloaders
- https://yazi-rs.github.io/docs/configuration/yazi/#plugin.previewers